### PR TITLE
Allow embed background colors to be set

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "[css]": {
-        "editor.formatOnSave": false
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "[css]": {
+        "editor.formatOnSave": false
+    }
+}

--- a/css/app.css
+++ b/css/app.css
@@ -8850,7 +8850,7 @@ img {
 }
 
 #widget .wrapper {
-    background-color: #fff;
+    background-color: var(--wrapper-bg-color);
     border: 2px solid #eee;
     border-radius: 4px;
     box-shadow: 1px 1px 0 #ccc, 2px 2px 2px #eee;

--- a/templates/widget.tmpl
+++ b/templates/widget.tmpl
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-transparent">
 <div id="widget">
-    <div class="wrapper clearfix">
+    <div class="wrapper clearfix" style="--wrapper-bg-color={{ .background }}">
         <div class="thumb" style="background-image: url({{ .project.Thumbnail }});"></div>
         <div class="meta">
       <span class="line lead">

--- a/web.go
+++ b/web.go
@@ -187,6 +187,7 @@ func GetProject(c *gin.Context) {
 			_ = templateEngine.ExecuteTemplate(buf, "widget.tmpl", gin.H{
 				"project":       properties,
 				"downloadCount": downloads,
+				"background":    c.DefaultQuery("background", "#fff"),
 			})
 			data := buf.Bytes()
 


### PR DESCRIPTION
Using a CSS variable to control the background color rather than hardcoded CSS value. Using DefaultQuery to select the query argument or falling back to white.