### PR TITLE
Removable border for embeds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "chat.disableAIFeatures": true,
     "go.testTimeout": "5m",
-    "go.diagnostic.vulncheck": "Off"
+    "go.diagnostic.vulncheck": "Off",
+    "[css]": {
+        "editor.formatOnSave": false
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
     "chat.disableAIFeatures": true,
     "go.testTimeout": "5m",
-    "go.diagnostic.vulncheck": "Off",
-    "[css]": {
-        "editor.formatOnSave": false
-    }
+    "go.diagnostic.vulncheck": "Off"
 }

--- a/css/app.css
+++ b/css/app.css
@@ -8851,12 +8851,21 @@ img {
 
 #widget .wrapper {
     background-color: var(--wrapper-bg-color);
-    border: 2px solid #eee;
-    border-radius: 4px;
-    box-shadow: 1px 1px 0 #ccc, 2px 2px 2px #eee;
     margin-right: 2px;
     min-width: 560px;
     padding: 12px
+}
+
+#widget .wrapper.border-default {
+    border: 2px solid #eee;
+    border-radius: 4px;
+    box-shadow: 1px 1px 0 #ccc, 2px 2px 2px #eee;
+}
+
+#widget .wrapper.border-none {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
 }
 
 #widget .wrapper.error {

--- a/templates/documentation.tmpl
+++ b/templates/documentation.tmpl
@@ -213,6 +213,20 @@
     </ul>
 
 
+    <p>
+        An optional <code class="roboto-mono bg-light-gray f6 ph2 pv1 br2">border</code> parameter can be included
+        when making a request. This will change the border rendering of the widget accordingly. For example:
+    </p>
+    <ul class="list pa0">
+        <li><span class="robot-mono b curse-orange">border=default</span>
+            Renders the widget with the default border and shadow
+        </li>
+        <li><span class="robot-mono b curse-orange">border=none</span>
+            Renders the widget without a border and shadow
+        </li>
+    </ul>
+
+
     <h2 id="documentation:responses">Responses</h2>
     <p>
         Each request response is a JSON document containing either project data or

--- a/templates/widget.tmpl
+++ b/templates/widget.tmpl
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-transparent">
 <div id="widget">
-    <div class="wrapper clearfix" style="--wrapper-bg-color: {{ .background }}">
+    <div class="wrapper clearfix{{ .borderClass }}" style="--wrapper-bg-color: {{ .background }}">
         <div class="thumb" style="background-image: url({{ .project.Thumbnail }});"></div>
         <div class="meta">
       <span class="line lead">

--- a/templates/widget.tmpl
+++ b/templates/widget.tmpl
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-transparent">
 <div id="widget">
-    <div class="wrapper clearfix{{ .borderClass }}" style="--wrapper-bg-color: {{ .background }}">
+    <div class="wrapper clearfix {{ .borderClass }}" style="--wrapper-bg-color: {{ .background }}">
         <div class="thumb" style="background-image: url({{ .project.Thumbnail }});"></div>
         <div class="meta">
       <span class="line lead">

--- a/web.go
+++ b/web.go
@@ -183,11 +183,20 @@ func GetProject(c *gin.Context) {
 		} else {
 			downloads := messagePrinter.Sprintf("%d\n", properties.Downloads["total"])
 
+			var borderClass string
+			switch c.Query("border") {
+			case "none":
+				borderClass = "border-none"
+			default:
+				borderClass = "border-default"
+			}
+
 			buf := &bytes.Buffer{}
 			_ = templateEngine.ExecuteTemplate(buf, "widget.tmpl", gin.H{
 				"project":       properties,
 				"downloadCount": downloads,
 				"background":    c.DefaultQuery("background", "#fff"),
+				"borderClass":   borderClass,
 			})
 			data := buf.Bytes()
 


### PR DESCRIPTION
Added another config option `border=default` (default), and `border=none`.

The latter will remove the existing border and box shadow so we can bring our own borders and/or shadows.

Also added documentation for this new property